### PR TITLE
Add 3rd party mac certificates recognition

### DIFF
--- a/step.go
+++ b/step.go
@@ -223,7 +223,7 @@ func searchIphoneAndMacCreatificates(lines []string) []string {
 
 	filteredCerts := []string{}
 	for _, cert := range certs {
-		if strings.HasPrefix(cert, "iPhone") || strings.HasPrefix(cert, "Mac") {
+		if strings.HasPrefix(cert, "iPhone") || strings.HasPrefix(cert, "Mac") || strings.HasPrefix(cert, "3rd Party Mac") {
 			filteredCerts = append(filteredCerts, cert)
 		}
 	}


### PR DESCRIPTION
OS X distribution certificates using the following naming:
`3rd Party Mac Developer Application: Your Name (ZYWNASDLW5)`

and it was ignored by certificates installer step.