### PR TITLE
Export BITRISE_PROVISIONING_PROFILE_PATH too

### DIFF
--- a/step.go
+++ b/step.go
@@ -468,14 +468,13 @@ func main() {
 
 		if len(provisioningProfileURLs) == 1 {
 			exportEnvironmentWithEnvman("BITRISE_PROVISIONING_PROFILE_ID", profileUUID)
+			exportEnvironmentWithEnvman("BITRISE_PROVISIONING_PROFILE_PATH", profileFinalPth)
 		}
 	}
-
 	if len(provisioningProfileURLs) != 1 {
 		fmt.Println()
-		fmt.Println(" (!) Won't export BITRISE_PROVISIONING_PROFILE_ID, only a single profile id can be exported and ${profile_count} specified!")
+		fmt.Println(" (!) Won't export BITRISE_PROVISIONING_PROFILE_ID and BITRISE_PROVISIONING_PROFILE_PATH, only a single profile id can be exported and ${profile_count} specified!")
 	}
-
 	fmt.Println()
 	fmt.Println("=> Done")
 }

--- a/step.yml
+++ b/step.yml
@@ -78,6 +78,12 @@ outputs:
     description: |-
       **Will only export the Profile ID if you specify
       a single Provisioning Profile!**
+- BITRISE_PROVISIONING_PROFILE_PATH:
+  opts:
+    title: Activated Provisioning Profile Path
+    description: |-
+      **Will only export the Profile Path if you specify
+      a single Provisioning Profile!**
 - BITRISE_CODE_SIGN_IDENTITY:
   opts:
     title: Activated Code Signing Certificate ID


### PR DESCRIPTION
When using tools like fastlane resign action (https://github.com/fastlane/fastlane/tree/c60edbf5080453c7d873f50fb02caff9748d9bf4/sigh#resign):
```
resign(
  ipa: 'path/to/ipa', # can omit if using the `ipa` action
  signing_identity: 'iPhone Distribution: Luka Mirosevic (0123456789)',
  provisioning_profile: 'path/to/profile', # can omit if using the `sigh` action
)
```
Is handy to have this step export the provisioning profile path so we don't have to manually
compose and hardcode the path where bitrise stores the provisioning profile.